### PR TITLE
Include favorites setting

### DIFF
--- a/src/components/Recommendations/Recommendations.js
+++ b/src/components/Recommendations/Recommendations.js
@@ -9,11 +9,12 @@ import './Recommendations.scss'
 
 function Recommendations() {
     const [prayerCount] = usePrayerRecord()
-    const [{ recommendationCount: count }] = useSettings()
+    const [settings] = useSettings()
     const [, { getRecommendations }] = useItems()
-    const { dates, favorites, lastPrayed } = getRecommendations(
-        count - prayerCount || 0
-    )
+    const { dates, favorites, lastPrayed } = getRecommendations({
+        prayerCount,
+        settings,
+    })
 
     const noRecommendations =
         !dates.length && !favorites.length && !lastPrayed.length

--- a/src/schemas/settings.js
+++ b/src/schemas/settings.js
@@ -1,11 +1,13 @@
 import * as yup from 'yup'
 
 export const FIELDS = {
+    includeFavorites: 'includeFavorites',
     listView: 'listView',
     recommendationCount: 'recommendationCount',
 }
 
 export const initialValues = {
+    [FIELDS.includeFavorites]: 'true',
     [FIELDS.listView]: 'All',
     [FIELDS.recommendationCount]: 3,
 }
@@ -16,6 +18,7 @@ export const defaultValues = (values = {}) => ({
 })
 
 export const validationSchema = yup.object().shape({
+    [FIELDS.includeFavorites]: yup.boolean().required('Required'),
     [FIELDS.listView]: yup.string().required('Required'),
     [FIELDS.recommendationCount]: yup.number().required('Required'),
 })

--- a/src/store/useItems.js
+++ b/src/store/useItems.js
@@ -84,7 +84,9 @@ function useItemsHook() {
         }
     }
 
-    function getRecommendations(length) {
+    function getRecommendations({ prayerCount, settings }) {
+        const { includeFavorites, recommendationCount } = settings
+        const length = recommendationCount - prayerCount || 0
         let count = 0
         const toBeSorted = []
 
@@ -110,7 +112,7 @@ function useItemsHook() {
             // Favorited items has second...
             if (item.favorite) {
                 recommendations.favorites.push(id)
-                count++
+                if (includeFavorites === 'true') count++
                 continue
             }
 

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -18,6 +18,7 @@ function SettingsView() {
             <Formik
                 enableReinitialize
                 initialValues={defaultValues({
+                    [FIELDS.includeFavorites]: settings.includeFavorites,
                     [FIELDS.listView]: settings.listView,
                     [FIELDS.recommendationCount]: settings.recommendationCount,
                 })}

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -29,21 +29,23 @@ function SettingsView() {
                         <InputField
                             description="Default is three"
                             label="Number of recommendations"
-                            name="recommendationCount"
+                            name={FIELDS.recommendationCount}
                             type="number"
                         />
                         <SelectField
-                            label="List view preference"
-                            name="listView"
+                            description="Include or exclude favorites from count"
+                            label="Favorites in recommendations"
+                            name={FIELDS.includeFavorites}
                         >
-                            {['All', 'By Type'].map((option) => (
-                                <option
-                                    key={option}
-                                    value={option.replace(/ /g, '')}
-                                >
-                                    {option}
-                                </option>
-                            ))}
+                            <option value="true">Include in count</option>
+                            <option value="false">Exclude from count</option>
+                        </SelectField>
+                        <SelectField
+                            label="List view preference"
+                            name={FIELDS.listView}
+                        >
+                            <option value="All">All</option>
+                            <option value="ByType">By Type</option>
                         </SelectField>
                         <FormFooter>
                             <Button disabled={!dirty} primary type="submit">


### PR DESCRIPTION
## Overview

Adds a setting to include or exclude favorites from the recommendation count. This will be particularly useful for users with a lot of favorites.

Fixes #84 