### PR TITLE
Data versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "pwoc",
     "version": "0.1.0",
+    "dataVersion": "0.1.0",
     "private": true,
     "dependencies": {
         "@reach/router": "^1.2.1",

--- a/src/data/previousVersions.js
+++ b/src/data/previousVersions.js
@@ -1,0 +1,4 @@
+// Maintain this list in chronological order: newest -> oldest
+const PREVIOUS_VERSIONS = ['0.1.0']
+
+export default PREVIOUS_VERSIONS

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -1,0 +1,15 @@
+import { dataVersion, name } from '../../package.json'
+
+const majorVersion = dataVersion.slice(0, dataVersion.indexOf('.'))
+
+export function buildKeyFromType(type) {
+    return buildKey(name, majorVersion, type)
+}
+
+export function buildKeyFromVersionAndType(version, type) {
+    return buildKey(name, version, type)
+}
+
+export function buildKey(name, version, type) {
+    return `${name}@${version}-${type}`
+}


### PR DESCRIPTION
## Features
- Tie data stored to major versions of a new `dataVersion` key in `package.json`
- Allows the freedom to version the data structure and the app separately
- When `dataVersion` changes, copy old data into new store, then remove store

## Bugs
- Fixes #93 