### PR TITLE
New date input: month and day

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -13,6 +13,7 @@ function FieldFactory({
     description,
     element,
     field = {},
+    hideLabel = false,
     id,
     label,
     meta = {},
@@ -37,7 +38,7 @@ function FieldFactory({
                 meta.error && `Field--error ${className}--error`
             )}
         >
-            {label && (
+            {label && !hideLabel && (
                 <label
                     className={`Field__label ${className}__label`}
                     htmlFor={elementId}
@@ -62,6 +63,7 @@ function FieldFactory({
                 className={`Field__input ${className}__input`}
                 id={elementId}
                 aria-describedby={descriptionId}
+                aria-label={hideLabel ? label : undefined}
                 aria-required={required}
                 {...field}
                 {...props}

--- a/src/components/Form/ItemFields.js
+++ b/src/components/Form/ItemFields.js
@@ -1,20 +1,72 @@
 import React from 'react'
-import { InputField, TextareaField } from './Form'
+import { InputField, SelectField, TextareaField } from './Form'
 import { FIELDS } from 'schemas/item'
+import Grid from 'components/Grid/Grid'
 
 export function Name(props) {
     return <InputField label="Name" name={FIELDS.name} required {...props} />
 }
 
-export function Date(props) {
+const MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+]
+
+export function Date() {
     return (
-        <InputField
-            description="You will get a prayer reminder on this date"
-            label="Special date"
-            name={FIELDS.date}
-            type="date"
-            {...props}
-        />
+        <div aria-labelledby="Date__label" className="Field" role="group">
+            <div id="Date__label" className="Field__label">
+                Special Date
+            </div>
+            <small
+                className="Field__description"
+                style={{ marginBottom: '0.5rem' }}
+            >
+                You will get a prayer reminder on this date
+            </small>
+            <Grid columns={2} gap={'0.5rem'}>
+                <Month />
+                <Day />
+            </Grid>
+        </div>
+    )
+}
+
+export function Day(props) {
+    const dayOptions = []
+    for (let i = 1; i <= 31; i++) {
+        dayOptions.push(
+            <option key={i} value={i}>
+                {i}
+            </option>
+        )
+    }
+    return (
+        <SelectField hideLabel label="Day" name={FIELDS.day} {...props}>
+            {dayOptions}
+        </SelectField>
+    )
+}
+
+export function Month(props) {
+    return (
+        <SelectField hideLabel label="Month" name={FIELDS.month} {...props}>
+            {MONTHS.map((month, index) => (
+                <option key={index} value={index}>
+                    {month}
+                </option>
+            ))}
+        </SelectField>
     )
 }
 

--- a/src/components/Form/ItemFields.js
+++ b/src/components/Form/ItemFields.js
@@ -53,6 +53,9 @@ export function Day(props) {
     }
     return (
         <SelectField hideLabel label="Day" name={FIELDS.day} {...props}>
+            <option key="day" value="">
+                Day
+            </option>
             {dayOptions}
         </SelectField>
     )
@@ -61,6 +64,9 @@ export function Day(props) {
 export function Month(props) {
     return (
         <SelectField hideLabel label="Month" name={FIELDS.month} {...props}>
+            <option key="month" value="">
+                Month
+            </option>
             {MONTHS.map((month, index) => (
                 <option key={index} value={index}>
                     {month}

--- a/src/schemas/item.js
+++ b/src/schemas/item.js
@@ -3,12 +3,16 @@ import * as yup from 'yup'
 export const FIELDS = {
     name: 'name',
     date: 'date',
+    day: 'day',
+    month: 'month',
     notes: 'notes',
 }
 
 export const initialValues = {
     [FIELDS.name]: '',
     [FIELDS.date]: '',
+    [FIELDS.day]: '',
+    [FIELDS.month]: '',
     [FIELDS.notes]: '',
 }
 
@@ -20,5 +24,7 @@ export const defaultValues = (values = {}) => ({
 export const validationSchema = yup.object().shape({
     [FIELDS.name]: yup.string().required('Required'),
     [FIELDS.date]: yup.string(),
+    [FIELDS.day]: yup.string(),
+    [FIELDS.month]: yup.string(),
     [FIELDS.notes]: yup.string(),
 })

--- a/src/store/useItems.js
+++ b/src/store/useItems.js
@@ -25,8 +25,9 @@ function useItemsHook() {
 
     function add({
         name,
-        date,
+        day,
         favorite = false,
+        month,
         notes = '',
         prayerRecord = [],
         tags = [],
@@ -34,9 +35,17 @@ function useItemsHook() {
     }) {
         const id = uuid()
         const shallow = { ...state }
+
+        let date = null
+        if (day && month) {
+            date = dayjs()
+                .month(month)
+                .date(day)
+        }
+
         shallow[id] = {
             name,
-            date: date ? dayjs(date) : null,
+            date,
             favorite,
             notes,
             prayerRecord,
@@ -50,8 +59,13 @@ function useItemsHook() {
         return Object.keys(state).length > 0
     }
 
-    function edit(id, updates) {
+    function edit(id, { day, month, ...updates }) {
         const shallow = { ...state }
+        if (day && month) {
+            updates.date = dayjs()
+                .month(month)
+                .date(day)
+        }
         shallow[id] = {
             ...shallow[id],
             ...updates,

--- a/src/views/AddItemView.js
+++ b/src/views/AddItemView.js
@@ -14,10 +14,11 @@ function AddItemView({ type }) {
     const [, { add }] = useItems()
 
     function onSubmit(values) {
-        const { date, name, notes } = values
+        const { day, month, name, notes } = values
 
         add({
-            date,
+            day,
+            month,
             name,
             notes,
             type,

--- a/src/views/EditView.js
+++ b/src/views/EditView.js
@@ -26,22 +26,25 @@ function EditView(props) {
     }
 
     function onSubmit(values) {
-        const { date, name, notes } = values
+        const { day, month, name, notes } = values
 
         edit(props.id, {
-            date,
+            day,
+            month,
             name,
             notes,
         })
 
         navigate(buildRoute.item(props.id))
     }
+    const date = dayjs(data.date)
 
     return (
         <ViewContainer title="Edit" backTo={buildRoute.item(props.id)}>
             <Formik
                 initialValues={defaultValues({
-                    [FIELDS.date]: dayjs(data.date).format('YYYY-MM-DD') || '',
+                    [FIELDS.day]: date.date() || '',
+                    [FIELDS.month]: date.month() || '',
                     [FIELDS.name]: data.name,
                     [FIELDS.notes]: data.notes,
                 })}


### PR DESCRIPTION
## Description

The default date input is painful (#97), and since the app is not using the year of a special date, it made sense to replace the old date input with month and day select fields.

This allows users to more easily and painlessly select special date for their items.

## Issues

Fixes #97 