### PR TITLE
Fixed height*

### DIFF
--- a/src/components/ViewContainer/ViewContainer.scss
+++ b/src/components/ViewContainer/ViewContainer.scss
@@ -1,8 +1,13 @@
 .ViewContainer {
     display: flex;
     flex-direction: column;
-    max-height: 100vh;
-    min-height: 100vh;
+
+    // Fill screen on mobile browsers
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: 0;
 
     &__main {
         flex: 1;

--- a/src/components/ViewContent/ViewContent.scss
+++ b/src/components/ViewContent/ViewContent.scss
@@ -1,5 +1,4 @@
 .ViewContent {
-    height: calc(100% - 2rem);
     margin-left: auto;
     margin-right: auto;
     max-width: 600px;


### PR DESCRIPTION
## Description

To save space, mobile browsers push the viewport down to accommodate the height of the toolbar. This resulted in part of the view being "too big" on mobile, despite the fact that the height was pegged to the height of the viewport.

By tweaking a few styles, this PR fixes the height of the view to the height of the visible viewport.