### PR TITLE
Open debug mode on PWA

### DIFF
--- a/src/components/ViewHeader/ViewHeader.js
+++ b/src/components/ViewHeader/ViewHeader.js
@@ -1,12 +1,20 @@
 import React from 'react'
+import { navigate } from '@reach/router'
 import Grid from 'components/Grid/Grid'
 import LinkButton from 'components/LinkButton/LinkButton'
 import ViewContent from 'components/ViewContent/ViewContent'
 import APP_NAME from 'constants/appName'
+import useCount from 'hooks/useCount'
 
 import './ViewHeader.scss'
 
 function ViewHeader({ actionButton = null, backTo = '/', title }) {
+    const [count, countUp] = useCount()
+    React.useEffect(() => {
+        if (count === 10) {
+            navigate('?debug=true')
+        }
+    }, [count])
     const shouldRenderBackButton = window.location.pathname !== '/'
     return (
         <header className="ViewHeader">
@@ -26,7 +34,15 @@ function ViewHeader({ actionButton = null, backTo = '/', title }) {
                             to={backTo}
                         />
                     )}
-                    <h1 className="ViewHeader__heading">{title || APP_NAME}</h1>
+                    {/*
+                        A11Y NOTE:
+                        The following onclick handler is for debug purposes only.
+                        There is no app functionality that is inaccessible to
+                        non-mouse users.
+                    */}
+                    <h1 className="ViewHeader__heading" onClick={countUp}>
+                        {title || APP_NAME}
+                    </h1>
                     {actionButton}
                 </Grid>
             </ViewContent>

--- a/src/hooks/useCount.js
+++ b/src/hooks/useCount.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export default function useCount(start = 0) {
+    const [count, setCount] = React.useState(start)
+    const up = () => setCount(count + 1)
+    const down = () => setCount(count - 1)
+    return [count, up, down]
+}


### PR DESCRIPTION
## Descriptions

PWAs do not have access to the address bar, which prevents them from adding the debug search query. To enable debugging in PWAs, I took a note from Google's book and added a secret "tap _x_ times to activate" to the heading.

This does require a mouse or finger to tap the header, but it is not connected to any app functionality. I'd be happy to look at this again for a more accessible solution.