### PR TITLE
Add fallback for Date().getTime()

### DIFF
--- a/src/store/useItems.js
+++ b/src/store/useItems.js
@@ -144,8 +144,10 @@ function useItemsHook() {
         if (count < length && toBeSorted.length > 0) {
             recommendations.lastPrayed = toBeSorted
                 .sort((a, b) => {
-                    const aTime = new Date(state[a].prayerRecord[0]).getTime()
-                    const bTime = new Date(state[b].prayerRecord[0]).getTime()
+                    const aTime =
+                        new Date(state[a].prayerRecord[0]).getTime() || 0
+                    const bTime =
+                        new Date(state[b].prayerRecord[0]).getTime() || 0
                     if (aTime < bTime) {
                         return -1
                     } else if (aTime > bTime) {


### PR DESCRIPTION
## Description
Never prayer for items were excluded from prayer recommendations. It's my theory that this was due to using `Date().getTime()` for the value, which was returning something unexpected. By defaulting the date values to compare to `0`, we can better ensure that "Nevers" are included.

## Issues
- Fixes #121